### PR TITLE
Spree 1.3 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-2-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '1-3-stable'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Spree.config do |config|
   admin_emails = admin_role.users.map(&:email).join(',')
 
   # comma separated list of emails
-  config.stock_notifications_list = admin_emails
+  config.low_stock_notification_emails = admin_emails
+  config.out_of_stock_notification_emails = admin_emails
 
   # when stock level reaches the "low stock threshold", admins will be notified. Default is 1
   config.low_stock_threshold = 2

--- a/app/mailers/stock_mailer.rb
+++ b/app/mailers/stock_mailer.rb
@@ -1,18 +1,17 @@
 class StockMailer < Spree::BaseMailer
-  def out_of_stock(stock_item)
-    default_mail(stock_item)
+  def out_of_stock(variant)
+    stock_mail(variant, Spree::Config.out_of_stock_notification_emails)
   end
 
-  def low_stock(stock_item)
-    default_mail(stock_item)
+  def low_stock(variant)
+    stock_mail(variant, Spree::Config.low_stock_notification_emails)
   end
 
-private
+  private
 
-  def default_mail(stock_item, options = {})
-    @stock_item = stock_item
-    @variant = stock_item.variant
-    @product = stock_item.variant.product
+  def stock_mail(variant, recipients, options = {})
+    @variant = variant
+    @product = variant.product
 
     if @variant.is_master
       @url = spree.admin_product_variant_url(@product, @variant)
@@ -20,7 +19,6 @@ private
       @url = spree.admin_product_url(@product)
     end
 
-    mail({from: from_address, to: Spree::Config.stock_notifications_list}.merge(options))
+    mail({ from: from_address, to: recipients }.merge(options))
   end
-
 end

--- a/app/models/variant_decorator.rb
+++ b/app/models/variant_decorator.rb
@@ -1,0 +1,3 @@
+Spree::Variant.class_eval do
+  include StockNotification
+end

--- a/app/views/stock_mailer/low_stock.html.erb
+++ b/app/views/stock_mailer/low_stock.html.erb
@@ -3,5 +3,5 @@
 </h2>
 
 <p>
-  <%= @stock_item.count_on_hand %> units remaining
+  <%= @variant.count_on_hand %> units remaining
 </p>

--- a/app/views/stock_mailer/out_of_stock.html.erb
+++ b/app/views/stock_mailer/out_of_stock.html.erb
@@ -3,5 +3,5 @@
 </h2>
 
 <p>
-  <%= @stock_item.count_on_hand %> units remaining
+  <%= @variant.count_on_hand %> units remaining
 </p>

--- a/lib/generators/spree_stock_notifications/install/templates/spree_stock_notifications.rb
+++ b/lib/generators/spree_stock_notifications/install/templates/spree_stock_notifications.rb
@@ -4,7 +4,8 @@ Spree.config do |config|
   admin_emails = admin_role.users.map(&:email).join(',')
 
   # set comma separated list of emails
-  config.stock_notifications_list = admin_emails
+  config.low_stock_notification_emails = admin_emails
+  config.out_of_stock_notification_emails = admin_emails
 
   # when stock level reaches the "low stock threshold", admins will be notified. Default is 1
   config.low_stock_threshold = 2

--- a/lib/spree_stock_notifications/engine.rb
+++ b/lib/spree_stock_notifications/engine.rb
@@ -18,7 +18,7 @@ module SpreeStockNotifications
     end
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
+      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
     end

--- a/lib/spree_stock_notifications/engine.rb
+++ b/lib/spree_stock_notifications/engine.rb
@@ -12,12 +12,9 @@ module SpreeStockNotifications
     initializer "spree_stock_notifications.environment", before: :load_config_initializers do |app|
       Spree::AppConfiguration.class_eval do
         preference :low_stock_threshold,      :integer, default: 1
-        preference :stock_notifications_list, :string
+        preference :low_stock_notification_emails, :string
+        preference :out_of_stock_notification_emails, :string
       end
-    end
-
-    initializer "spree_stock_notifications.customizations" do
-      Spree::StockItem.send :include, StockNotification
     end
 
     def self.activate

--- a/spree_stock_notifications.gemspec
+++ b/spree_stock_notifications.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2.0'
+  s.add_dependency 'spree_core', '~> 1.3.0'
   s.add_dependency 'spree_backend'
 
   s.add_development_dependency 'capybara', '~> 2.1'

--- a/spree_stock_notifications.gemspec
+++ b/spree_stock_notifications.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_stock_notifications'
-  s.version     = '2.2.0'
+  s.version     = '1.3.0'
   s.summary     = 'Stock notifications'
   s.description = 'Notifies when stock levels are low or item goes out of stock'
   s.required_ruby_version = '>= 1.9.3'
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '~> 1.3.0'
-  s.add_dependency 'spree_backend'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
- a version for people still on Spree 1.3
- separate email lists for low stock and out-of-stock
