### PR TITLE
Update gemspec to be more flexible with patch versions

### DIFF
--- a/spec/models/stock_item_spec.rb
+++ b/spec/models/stock_item_spec.rb
@@ -6,6 +6,7 @@ describe Spree::StockItem, type: :model do
   let(:mail) { double(:mail) }
 
   before do
+    allow_any_instance_of(Spree::Store).to receive(:mail_from_address).and_return('test@example.com')
     Spree::Config.stock_notifications_list = "jack@example.com,jill@example.com"
   end
 

--- a/spree_stock_notifications.gemspec
+++ b/spree_stock_notifications.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', version
-  s.add_dependency 'spree_backend', version
+  s.add_dependency 'spree_core', "~> #{version}"
+  s.add_dependency 'spree_backend', "~> #{version}"
 
   s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
Allow different patch versions of 3.0.x rather than explicitly requiring 3.0.0.

Also fixed one failing test by stubbing `Spree::Store.mail_from_address`.
